### PR TITLE
Added number of calls to profile objects

### DIFF
--- a/v8-profiler.js
+++ b/v8-profiler.js
@@ -56,7 +56,7 @@ function inspectorObjectFor(node) {
         lineNumber: node.lineNumber,
         totalTime: node.totalTime,
         selfTime: node.selfTime,
-        numberOfCalls: 0,
+        numberOfCalls: node.selfSamplesCount,
         visible: true,
         callUID: node.callUid,
         children: []


### PR DESCRIPTION
Hi! I made a tiny fix to the inspectorObjectFor() function so the number of calls are properly extracted from the profile node.
