### PR TITLE
header: add #include <node.h> for Windows

### DIFF
--- a/cpu_profiler.h
+++ b/cpu_profiler.h
@@ -1,8 +1,8 @@
 #ifndef NODE_CPU_PROFILER_
 #define NODE_CPU_PROFILER_
 
-#include <v8-profiler.h>
 #include <node.h>
+#include <v8-profiler.h>
 
 using namespace v8;
 using namespace node;

--- a/heap_profiler.h
+++ b/heap_profiler.h
@@ -1,8 +1,8 @@
 #ifndef NODE_HEAP_PROFILER_
 #define NODE_HEAP_PROFILER_
 
-#include <v8-profiler.h>
 #include <node.h>
+#include <v8-profiler.h>
 
 using namespace v8;
 using namespace node;

--- a/profile.h
+++ b/profile.h
@@ -1,6 +1,7 @@
 #ifndef NODE_PROFILE_
 #define NODE_PROFILE_
 
+#include <node.h>
 #include <v8-profiler.h>
 
 using namespace v8;

--- a/profile_node.h
+++ b/profile_node.h
@@ -3,6 +3,7 @@
 #ifndef NODE_PROFILE_NODE_
 #define NODE_PROFILE_NODE_
 
+#include <node.h>
 #include <v8-profiler.h>
 
 using namespace v8;

--- a/snapshot.h
+++ b/snapshot.h
@@ -3,6 +3,7 @@
 #ifndef NODE_SNAPSHOT_
 #define NODE_SNAPSHOT_
 
+#include <node.h>
 #include <v8-profiler.h>
 
 using namespace v8;


### PR DESCRIPTION
Supersedes https://github.com/3y3/v8-profiler/pull/1

Unfortunately, on Windows, `#include <node.h>` is required in every header that declares v8 or uv structures, to prevent the MSVC compiler from generating duplicate symbols.
