### PR TITLE
Remove bottom up root

### DIFF
--- a/src/cpu_profile.cc
+++ b/src/cpu_profile.cc
@@ -92,9 +92,6 @@ namespace nodex {
     profile->Set(NanNew<String>("startTime"), start_time);
     profile->Set(NanNew<String>("endTime"),   end_time);
     profile->Set(NanNew<String>("samples"),   samples);
-#else
-    Handle<Value> bottom = ProfileNode::New(node->GetBottomUpRoot());
-    profile->Set(NanNew<String>("bottomRoot"), bottom);
 #endif
     
     Local<Array> profiles = NanNew<Array>(Profile::profiles);

--- a/test/cpu_cprofiler.js
+++ b/test/cpu_cprofiler.js
@@ -73,7 +73,7 @@ describe('CPU', function() {
       var profile = binding.cpu.stopProfiling();
       var properties = NODE_V_11 ?
         ['delete', 'typeId', 'uid', 'title', 'head', 'startTime', 'endTime', 'samples'] :
-        ['delete', 'typeId', 'uid', 'title', 'head', 'bottomRoot'];
+        ['delete', 'typeId', 'uid', 'title', 'head'];
         
       properties.forEach(function(prop) {
         expect(profile).to.have.property(prop);


### PR DESCRIPTION
recent chrome can work without a bottomUpRoot
it will generate it's own itself.
so better to stop wasting resources building it.
(this also reduce the .cpuprofile file size by nearly half)

sample cpuprofile: [get it here](https://gist.githubusercontent.com/arunoda/20bf8f5e4d7014ac3e56/raw/d5b9c21313a3d0863dd63786676ff3db519577b7/gistfile1.txt)
discussion: https://groups.google.com/forum/#!topic/v8-dev/Jms7ycmqcK0
