### PR TITLE
nan: upgrade nan to 1.5.3 to make v8-profiler compat with io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "v8-profiler",
   "dependencies": {
     "node-pre-gyp": "^0.5.0",
-    "nan": "~1.2.0"
+    "nan": "~1.5.3"
   },
   "bundledDependencies":["node-pre-gyp"],
   "devDependencies": {

--- a/src/cpu_profile.cc
+++ b/src/cpu_profile.cc
@@ -11,6 +11,7 @@ namespace nodex {
   using v8::Local;
   using v8::Object;
   using v8::ObjectTemplate;
+  using v8::FunctionTemplate;
   using v8::Persistent;
   using v8::String;
   using v8::Function;
@@ -23,7 +24,8 @@ namespace nodex {
   void Profile::Initialize () {
     NanScope();
     
-    Local<ObjectTemplate> o = NanNew<ObjectTemplate>();
+    Local<FunctionTemplate> f = NanNew<FunctionTemplate>();
+    Local<ObjectTemplate> o = f->InstanceTemplate();
     o->SetInternalFieldCount(1);
     NODE_SET_METHOD(o, "delete", Profile::Delete);
     NanAssignPersistent(profile_template_, o);

--- a/src/cpu_profile_node.cc
+++ b/src/cpu_profile_node.cc
@@ -37,7 +37,7 @@ namespace nodex {
     profile_node->Set(NanNew<String>("bailoutReason"), NanNew<String>("no reason"));
     profile_node->Set(NanNew<String>("id"),            NanNew<Integer>(UIDCounter++));
     //TODO(3y3): profile_node->Set(NanNew<String>("scriptId"),      NanNew<Integer>(node->GetScriptId()));
-    profile_node->Set(NanNew<String>("hitCount"),      NanNew<Integer>(node->GetSelfSamplesCount()));
+    profile_node->Set(NanNew<String>("hitCount"),      NanNew(node->GetSelfSamplesCount()));
 #endif
     profile_node->Set(NanNew<String>("children"),      children);
     

--- a/src/heap_graph_node.cc
+++ b/src/heap_graph_node.cc
@@ -9,6 +9,7 @@ namespace nodex {
   using v8::Local;
   using v8::Object;
   using v8::ObjectTemplate;
+  using v8::FunctionTemplate;
   using v8::Persistent;
   using v8::String;
   using v8::Value;
@@ -20,7 +21,8 @@ namespace nodex {
   void GraphNode::Initialize () {
     NanScope();
     
-    Local<ObjectTemplate> o = NanNew<ObjectTemplate>();
+    Local<FunctionTemplate> f = NanNew<FunctionTemplate>();
+    Local<ObjectTemplate> o = f->InstanceTemplate();
     Local<Object> _cache = NanNew<Object>();
     o->SetInternalFieldCount(1);
 #if (NODE_MODULE_VERSION <= 0x000B)

--- a/src/heap_snapshot.cc
+++ b/src/heap_snapshot.cc
@@ -12,6 +12,7 @@ namespace nodex {
   using v8::Local;
   using v8::Object;
   using v8::ObjectTemplate;
+  using v8::FunctionTemplate;
   using v8::Persistent;
   using v8::SnapshotObjectId;
   using v8::String;
@@ -25,7 +26,8 @@ namespace nodex {
   void Snapshot::Initialize () {
     NanScope();
     
-    Local<ObjectTemplate> o = NanNew<ObjectTemplate>();
+    Local<FunctionTemplate> f = NanNew<FunctionTemplate>();
+    Local<ObjectTemplate> o = f->InstanceTemplate();
     o->SetInternalFieldCount(1);
     o->SetAccessor(NanNew<String>("root"), Snapshot::GetRoot);
     NODE_SET_METHOD(o, "getNode", Snapshot::GetNode);


### PR DESCRIPTION
- adapting creation of `ObjectTemplate`
- adapting one `NanNew<Integer>` which was ambiguous with new version of nan


I verified that this version works with iojs, node 0.10 and node 0.11.
The reason I upgraded nan to `1.5.3` instead of the latest `1.6` for now is that it is not compatible with io.js.
I'm filing a related issue with nan.

Here is the truncated output I got when rebuilding v8-profiler and running tests for different node versions:

```
➝  nave use 0.11
Already installed: 0.11.15
using 0.11.15

➝  node-gyp rebuild && npm test

21 passing (305ms)

++++++++

➝  nave use 0.10
Already installed: 0.10.35
using 0.10.35

➝  node-gyp rebuild && npm test


21 passing (541ms)

++++++++

➝  ../iojs/iojs --version
v1.0.4

node-gyp rebuild --nodedir ../iojs/ && ../iojs/deps/npm/bin/npm-cli.js test

21 passing (549ms)
```

In order to run `node-gyp rebuild` I temporarily changed the `binding.gyp` file as follows (not part of PR):

```diff
diff --git a/binding.gyp b/binding.gyp
index 1f87c9f..5acba86 100644
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,11 +20,11 @@
     {
       "target_name": "action_after_build",
       "type": "none",
-      "dependencies": [ "<(module_name)" ],
+#      "dependencies": [ "<(module_name)" ],
       "copies": [
         {
-          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
-          "destination": "<(module_path)"
+          "files": [ "<(PRODUCT_DIR)/profiler.node" ],
+          "destination": "build"
         }
       ]
     }
```