### PR TITLE
snapshot: adding snapshot.toJSON convenience method

### DIFF
--- a/test/cpu_cprofiler.js
+++ b/test/cpu_cprofiler.js
@@ -1,4 +1,5 @@
 const binding = require('../build/Release/profiler'),
+      profiler = require('../'),
       expect  = require('chai').expect;
 
 const NODE_V_10 = /^v0\.10\.\d+$/.test(process.version),
@@ -209,6 +210,15 @@ describe('HEAP', function() {
           done();
         }
       );
+    });
+
+    it('Snapshot.toJSON', function(done) {
+      var snapshot = profiler.takeSnapshot();
+      snapshot.toJSON(function callback(err, json) {
+        expect(!err);
+        expect(JSON.parse.bind(JSON, json)).to.not.throw();
+        done();
+      });
     });
     
   });

--- a/v8-profiler.js
+++ b/v8-profiler.js
@@ -58,6 +58,21 @@ Snapshot.prototype.nodeCounts = function() {
   return objects;
 };
 
+Snapshot.prototype.toJSON = function toJSON(cb) {
+  var chunks = [];
+
+  function onChunk(chunk, len) {
+    chunks.push(chunk);
+  }
+
+  function onDone() {
+    var s = chunks.join('');
+    cb(null, s);
+  }
+
+  this.serialize(onChunk, onDone);
+};
+
 function CpuProfile() {}
 
 CpuProfile.prototype.getHeader = function() {


### PR DESCRIPTION
In some cases you want JSON to parse or write to a file.
The intuitive way is to `JSON.parse` a snapshot object but that fails due to circular references.

This method makes that easier.

As a note, I tried `Buffer.concat(chunks, chunks.length)` instead the `.join` call without success.