### PR TITLE
Upgrade to nan v2.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - export NODE_VERSION="0.12"
     - export NODE_VERSION="1"
     - export NODE_VERSION="2"
+    - export NODE_VERSION="3"
   global:
     - node_pre_gyp_region="eu-central-1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
       platform: x64
     - NODE_VERSION: 2
       platform: x86
+    - NODE_VERSION: 3
+      platform: x86
     - NODE_VERSION: 0.12
       platform: x64
     - NODE_VERSION: 0.12

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "v8-profiler",
   "dependencies": {
     "node-pre-gyp": "^0.6.5",
-    "nan": "~1.8.4"
+    "nan": "~2.0.5"
   },
   "devDependencies": {
     "aws-sdk": "^2.0.0",

--- a/src/cpu_profile.cc
+++ b/src/cpu_profile.cc
@@ -12,50 +12,45 @@ namespace nodex {
   using v8::Object;
   using v8::ObjectTemplate;
   using v8::FunctionTemplate;
-  using v8::Persistent;
   using v8::String;
   using v8::Function;
   using v8::Value;
 
-  Persistent<ObjectTemplate> Profile::profile_template_;
-  Persistent<Array> Profile::profiles;
+  Nan::Persistent<ObjectTemplate> Profile::profile_template_;
+  Nan::Persistent<Array> Profile::profiles;
   uint32_t Profile::uid_counter = 0;
   
   void Profile::Initialize () {
-    NanScope();
+    Nan::HandleScope scope;
     
-    Local<FunctionTemplate> f = NanNew<FunctionTemplate>();
+    Local<FunctionTemplate> f = Nan::New<FunctionTemplate>();
     Local<ObjectTemplate> o = f->InstanceTemplate();
     o->SetInternalFieldCount(1);
-    NODE_SET_METHOD(o, "delete", Profile::Delete);
-    NanAssignPersistent(profile_template_, o);
+    Nan::SetMethod(o, "delete", Profile::Delete);
+    profile_template_.Reset(o);
   }
 
   NAN_METHOD(Profile::Delete) {
-    NanScope();
-    
-    Handle<Object> self = args.This();
-    void* ptr = NanGetInternalFieldPointer(self, 0);
-    Local<Array> profiles = NanNew<Array>(Profile::profiles);
+    Handle<Object> self = info.This();
+    void* ptr = Nan::GetInternalFieldPointer(self, 0);
+    Local<Array> profiles = Nan::New<Array>(Profile::profiles);
     
     uint32_t count = profiles->Length();
     for (uint32_t index = 0; index < count; index++) {
-      if (profiles->Get(index) == args.This()) {
+      if (profiles->Get(index) == info.This()) {
         Local<Value> argv[2] = {
-          NanNew<Integer>(index),
-          NanNew<Integer>(1)
+          Nan::New<Integer>(index),
+          Nan::New<Integer>(1)
         };
-        Handle<Function>::Cast(profiles->Get(NanNew<String>("splice")))->Call(profiles, 2, argv);
+        Handle<Function>::Cast(profiles->Get(Nan::New<String>("splice").ToLocalChecked()))->Call(profiles, 2, argv);
         break;
       }
     }
     static_cast<CpuProfile*>(ptr)->Delete();
-
-    NanReturnUndefined();
   }
 
   Handle<Value> Profile::New (const CpuProfile* node) {
-    NanEscapableScope();
+    Nan::EscapableHandleScope scope;
     
     if (profile_template_.IsEmpty()) {
       Profile::Initialize();
@@ -63,42 +58,42 @@ namespace nodex {
     
     uid_counter++;
       
-    Local<Object> profile = NanNew(profile_template_)->NewInstance();
-    NanSetInternalFieldPointer(profile, 0, const_cast<CpuProfile*>(node));
+    Local<Object> profile = Nan::New(profile_template_)->NewInstance();
+    Nan::SetInternalFieldPointer(profile, 0, const_cast<CpuProfile*>(node));
     
-    Local<Value> CPU = NanNew<String>("CPU");
-    Local<Value> uid = NanNew<Integer>(uid_counter);
+    Local<Value> CPU = Nan::New<String>("CPU").ToLocalChecked();
+    Local<Value> uid = Nan::New<Integer>(uid_counter);
     Handle<String> title = node->GetTitle();
     if (!title->Length()) {
       char _title[32];
       sprintf(_title, "Profile %i", uid_counter);
-      title = NanNew<String>(_title);
+      title = Nan::New<String>(_title).ToLocalChecked();
     }
     Handle<Value> head = ProfileNode::New(node->GetTopDownRoot());
     
-    profile->Set(NanNew<String>("typeId"),    CPU);
-    profile->Set(NanNew<String>("uid"),       uid);
-    profile->Set(NanNew<String>("title"),     title);
-    profile->Set(NanNew<String>("head"),      head);
+    profile->Set(Nan::New<String>("typeId").ToLocalChecked(),    CPU);
+    profile->Set(Nan::New<String>("uid").ToLocalChecked(),       uid);
+    profile->Set(Nan::New<String>("title").ToLocalChecked(),     title);
+    profile->Set(Nan::New<String>("head").ToLocalChecked(),      head);
 
 #if (NODE_MODULE_VERSION > 0x000B)
-    Local<Value> start_time = NanNew<Number>(node->GetStartTime()/1000000);
-    Local<Value> end_time = NanNew<Number>(node->GetEndTime()/1000000);
-    Local<Array> samples = NanNew<Array>();
+    Local<Value> start_time = Nan::New<Number>(node->GetStartTime()/1000000);
+    Local<Value> end_time = Nan::New<Number>(node->GetEndTime()/1000000);
+    Local<Array> samples = Nan::New<Array>();
     
     uint32_t count = node->GetSamplesCount();
     for (uint32_t index = 0; index < count; ++index) {
-      samples->Set(index, NanNew<Integer>(node->GetSample(index)->GetNodeId()));
+      samples->Set(index, Nan::New<Integer>(node->GetSample(index)->GetNodeId()));
     }
     
-    profile->Set(NanNew<String>("startTime"), start_time);
-    profile->Set(NanNew<String>("endTime"),   end_time);
-    profile->Set(NanNew<String>("samples"),   samples);
+    profile->Set(Nan::New<String>("startTime").ToLocalChecked(), start_time);
+    profile->Set(Nan::New<String>("endTime").ToLocalChecked(),   end_time);
+    profile->Set(Nan::New<String>("samples").ToLocalChecked(),   samples);
 #endif
     
-    Local<Array> profiles = NanNew<Array>(Profile::profiles);
+    Local<Array> profiles = Nan::New<Array>(Profile::profiles);
     profiles->Set(profiles->Length(), profile);
     
-    return NanEscapeScope(profile);
+    return scope.Escape(profile);
   }
 }

--- a/src/cpu_profile.h
+++ b/src/cpu_profile.h
@@ -9,11 +9,11 @@ namespace nodex {
   class Profile {
    public:
     static v8::Handle<v8::Value> New(const v8::CpuProfile* node);
-    static v8::Persistent<v8::Array> profiles;
+    static Nan::Persistent<v8::Array> profiles;
    private:
     static NAN_METHOD(Delete);
     static void Initialize();
-    static v8::Persistent<v8::ObjectTemplate> profile_template_;
+    static Nan::Persistent<v8::ObjectTemplate> profile_template_;
     static uint32_t uid_counter;
   };
 

--- a/src/cpu_profile_node.cc
+++ b/src/cpu_profile_node.cc
@@ -15,7 +15,7 @@ namespace nodex {
 
 #if (NODE_MODULE_VERSION >= 42)
   Handle<Value> ProfileNode::GetLineTicks_(const CpuProfileNode* node) {
-    NanEscapableScope();
+    Nan::EscapableHandleScope scope;
 
     uint32_t count = node->GetHitLineCount();
     v8::CpuProfileNode::LineTick *entries = new v8::CpuProfileNode::LineTick[count];
@@ -23,59 +23,59 @@ namespace nodex {
 
     Local<Value> lineTicks;
     if (result) {
-      Local<Array> array = NanNew<Array>(count);
+      Local<Array> array = Nan::New<Array>(count);
       for (uint32_t index = 0; index < count; index++) {
-        Local<Object> tick = NanNew<Object>();
-        tick->Set(NanNew<String>("line"),     NanNew<Integer>(entries[index].line));
-        tick->Set(NanNew<String>("hitCount"), NanNew<Integer>(entries[index].hit_count));
+        Local<Object> tick = Nan::New<Object>();
+        tick->Set(Nan::New<String>("line").ToLocalChecked(),     Nan::New<Integer>(entries[index].line));
+        tick->Set(Nan::New<String>("hitCount").ToLocalChecked(), Nan::New<Integer>(entries[index].hit_count));
         array->Set(index, tick);
       }
       lineTicks = array;
     } else {
-      lineTicks = NanNull();
+      lineTicks = Nan::Null();
     }
 
     delete[] entries;
-    return NanEscapeScope(lineTicks);
+    return scope.Escape(lineTicks);
   }
 #endif
   
   Handle<Value> ProfileNode::New (const CpuProfileNode* node) {
-    NanEscapableScope();
+    Nan::EscapableHandleScope scope;
     
     int32_t count = node->GetChildrenCount();
-    Local<Object> profile_node = NanNew<Object>();
-    Local<Array> children = NanNew<Array>(count);
+    Local<Object> profile_node = Nan::New<Object>();
+    Local<Array> children = Nan::New<Array>(count);
     
     for (int32_t index = 0; index < count; index++) {
       children->Set(index, ProfileNode::New(node->GetChild(index)));
     }
     
-    profile_node->Set(NanNew<String>("functionName"),  NanNew<String>(node->GetFunctionName()));
-    profile_node->Set(NanNew<String>("url"),           NanNew<String>(node->GetScriptResourceName()));
-    profile_node->Set(NanNew<String>("lineNumber"),    NanNew<Integer>(node->GetLineNumber()));
-    profile_node->Set(NanNew<String>("callUID"),       NanNew<Number>(node->GetCallUid()));
+    profile_node->Set(Nan::New<String>("functionName").ToLocalChecked(),  node->GetFunctionName());
+    profile_node->Set(Nan::New<String>("url").ToLocalChecked(),           node->GetScriptResourceName());
+    profile_node->Set(Nan::New<String>("lineNumber").ToLocalChecked(),    Nan::New<Integer>(node->GetLineNumber()));
+    profile_node->Set(Nan::New<String>("callUID").ToLocalChecked(),       Nan::New<Number>(node->GetCallUid()));
 #if (NODE_MODULE_VERSION > 0x000B)      
-    profile_node->Set(NanNew<String>("bailoutReason"), NanNew<String>(node->GetBailoutReason()));
-    profile_node->Set(NanNew<String>("id"),            NanNew<Integer>(node->GetNodeId()));
-    profile_node->Set(NanNew<String>("scriptId"),      NanNew<Integer>(node->GetScriptId()));
-    profile_node->Set(NanNew<String>("hitCount"),      NanNew<Integer>(node->GetHitCount()));
+    profile_node->Set(Nan::New<String>("bailoutReason").ToLocalChecked(), Nan::New<String>(node->GetBailoutReason()).ToLocalChecked());
+    profile_node->Set(Nan::New<String>("id").ToLocalChecked(),            Nan::New<Integer>(node->GetNodeId()));
+    profile_node->Set(Nan::New<String>("scriptId").ToLocalChecked(),      Nan::New<Integer>(node->GetScriptId()));
+    profile_node->Set(Nan::New<String>("hitCount").ToLocalChecked(),      Nan::New<Integer>(node->GetHitCount()));
 #else
-    profile_node->Set(NanNew<String>("bailoutReason"), NanNew<String>("no reason"));
-    profile_node->Set(NanNew<String>("id"),            NanNew<Integer>(UIDCounter++));
-    //TODO(3y3): profile_node->Set(NanNew<String>("scriptId"),      NanNew<Integer>(node->GetScriptId()));
-    profile_node->Set(NanNew<String>("hitCount"),      NanNew(node->GetSelfSamplesCount()));
+    profile_node->Set(Nan::New<String>("bailoutReason").ToLocalChecked(), Nan::New<String>("no reason").ToLocalChecked());
+    profile_node->Set(Nan::New<String>("id").ToLocalChecked(),            Nan::New<Integer>(UIDCounter++));
+    //TODO(3y3): profile_node->Set(Nan::New<String>("scriptId").ToLocalChecked(),      Nan::New<Integer>(node->GetScriptId()));
+    profile_node->Set(Nan::New<String>("hitCount").ToLocalChecked(),      Nan::New<Integer>(node->GetSelfSamplesCount()));
 #endif
-    profile_node->Set(NanNew<String>("children"),      children);
+    profile_node->Set(Nan::New<String>("children").ToLocalChecked(),      children);
 
 #if (NODE_MODULE_VERSION >= 42)
     Handle<Value> lineTicks = GetLineTicks_(node);
     if (!lineTicks->IsNull()) {
-      profile_node->Set(NanNew<String>("lineTicks"), lineTicks);
+      profile_node->Set(Nan::New<String>("lineTicks").ToLocalChecked(), lineTicks);
     }
 #endif
 
-    return NanEscapeScope(profile_node);
+    return scope.Escape(profile_node);
   }
 
 }

--- a/src/cpu_profiler.cc
+++ b/src/cpu_profiler.cc
@@ -13,43 +13,41 @@ namespace nodex {
   CpuProfiler::~CpuProfiler () {}
 
   void CpuProfiler::Initialize (Handle<Object> target) {
-    NanScope();
+    Nan::HandleScope scope;
     
-    Local<Object> cpuProfiler = NanNew<Object>();
-    Local<Array> profiles = NanNew<Array>();
+    Local<Object> cpuProfiler = Nan::New<Object>();
+    Local<Array> profiles = Nan::New<Array>();
     
-    NODE_SET_METHOD(cpuProfiler, "startProfiling", CpuProfiler::StartProfiling);
-    NODE_SET_METHOD(cpuProfiler, "stopProfiling", CpuProfiler::StopProfiling);
-    cpuProfiler->Set(NanNew<String>("profiles"), profiles);
+    Nan::SetMethod(cpuProfiler, "startProfiling", CpuProfiler::StartProfiling);
+    Nan::SetMethod(cpuProfiler, "stopProfiling", CpuProfiler::StopProfiling);
+    cpuProfiler->Set(Nan::New<String>("profiles").ToLocalChecked(), profiles);
     
-    NanAssignPersistent(Profile::profiles, profiles);
-    target->Set(NanNew<String>("cpu"), cpuProfiler);
+    Profile::profiles.Reset(profiles);
+    target->Set(Nan::New<String>("cpu").ToLocalChecked(), cpuProfiler);
   }
 
   NAN_METHOD(CpuProfiler::StartProfiling) {
-    NanScope();
-    
     bool recsamples = true;
-    Local<String> title = NanNew<String>("");
-    if (args.Length()) {
-      if (args.Length()>1) {
-        if (args[1]->IsBoolean()) {
-          recsamples = args[1]->ToBoolean()->Value();
-        } else if (!args[1]->IsUndefined()) {
-          return NanThrowTypeError("Wrong argument [1] type (wait Boolean)");
+    Local<String> title = Nan::New<String>("").ToLocalChecked();
+    if (info.Length()) {
+      if (info.Length()>1) {
+        if (info[1]->IsBoolean()) {
+          recsamples = info[1]->ToBoolean()->Value();
+        } else if (!info[1]->IsUndefined()) {
+          return Nan::ThrowTypeError("Wrong argument [1] type (wait Boolean)");
         }
-        if (args[0]->IsString()) {
-          title = args[0]->ToString();
-        } else if (!args[0]->IsUndefined()) {
-          return NanThrowTypeError("Wrong argument [0] type (wait String)");
+        if (info[0]->IsString()) {
+          title = info[0]->ToString();
+        } else if (!info[0]->IsUndefined()) {
+          return Nan::ThrowTypeError("Wrong argument [0] type (wait String)");
         }
       } else {
-        if (args[0]->IsString()) {
-          title = args[0]->ToString();
-        } else if (args[0]->IsBoolean()) {
-          recsamples = args[0]->ToBoolean()->Value();
-        } else if (!args[0]->IsUndefined()) {
-          return NanThrowTypeError("Wrong argument [0] type (wait String or Boolean)");
+        if (info[0]->IsString()) {
+          title = info[0]->ToString();
+        } else if (info[0]->IsBoolean()) {
+          recsamples = info[0]->ToBoolean()->Value();
+        } else if (!info[0]->IsUndefined()) {
+          return Nan::ThrowTypeError("Wrong argument [0] type (wait String or Boolean)");
         }
       }
     }
@@ -59,21 +57,17 @@ namespace nodex {
 #else
     v8::CpuProfiler::StartProfiling(title);
 #endif
-
-    NanReturnUndefined();
   }
 
   NAN_METHOD(CpuProfiler::StopProfiling) {
-    NanScope();
-
     const CpuProfile* profile;
     
-    Local<String> title = NanNew<String>("");
-    if (args.Length()) {
-      if (args[0]->IsString()) {
-        title = args[0]->ToString();
-      } else if (!args[0]->IsUndefined()) {
-        return NanThrowTypeError("Wrong argument [0] type (wait String)");
+    Local<String> title = Nan::New<String>("").ToLocalChecked();
+    if (info.Length()) {
+      if (info[0]->IsString()) {
+        title = info[0]->ToString();
+      } else if (!info[0]->IsUndefined()) {
+        return Nan::ThrowTypeError("Wrong argument [0] type (wait String)");
       }
     }
     
@@ -83,6 +77,6 @@ namespace nodex {
     profile = v8::CpuProfiler::StopProfiling(title);
 #endif
     
-    NanReturnValue(Profile::New(profile));
+    info.GetReturnValue().Set(Profile::New(profile));
   }
 } //namespace nodex

--- a/src/heap_graph_edge.cc
+++ b/src/heap_graph_edge.cc
@@ -11,45 +11,45 @@ namespace nodex {
   using v8::Value;
 
   Handle<Value> GraphEdge::New(const HeapGraphEdge* node) {
-    NanEscapableScope();
+    Nan::EscapableHandleScope scope;
     
-    Local<Object> graph_edge = NanNew<Object>();
+    Local<Object> graph_edge = Nan::New<Object>();
 
     Local<Value> type;
     switch (node->GetType()) {
       case HeapGraphEdge::kContextVariable :
-        type = NanNew<String>("ContextVariable");
+        type = Nan::New<String>("ContextVariable").ToLocalChecked();
         break;
       case HeapGraphEdge::kElement :
-        type = NanNew<String>("Element");
+        type = Nan::New<String>("Element").ToLocalChecked();
         break;
       case HeapGraphEdge::kProperty :
-        type = NanNew<String>("Property");
+        type = Nan::New<String>("Property").ToLocalChecked();
         break;
       case HeapGraphEdge::kInternal :
-        type = NanNew<String>("Internal");
+        type = Nan::New<String>("Internal").ToLocalChecked();
         break;
       case HeapGraphEdge::kHidden :
-        type = NanNew<String>("Hidden");
+        type = Nan::New<String>("Hidden").ToLocalChecked();
         break;
       case HeapGraphEdge::kShortcut :
-        type = NanNew<String>("Shortcut");
+        type = Nan::New<String>("Shortcut").ToLocalChecked();
         break;
       case HeapGraphEdge::kWeak :
-        type = NanNew<String>("Weak");
+        type = Nan::New<String>("Weak").ToLocalChecked();
         break;
       default :
-        type = NanNew<String>("Undefined");
+        type = Nan::New<String>("Undefined").ToLocalChecked();
     }
     Handle<Value> name = node->GetName();
     Handle<Value> from = GraphNode::New(node->GetFromNode());
     Handle<Value> to = GraphNode::New(node->GetToNode());
 
-    graph_edge->Set(NanNew<String>("type"), type);
-    graph_edge->Set(NanNew<String>("name"), name);
-    graph_edge->Set(NanNew<String>("from"), from);
-    graph_edge->Set(NanNew<String>("to"), to);
+    graph_edge->Set(Nan::New<String>("type").ToLocalChecked(), type);
+    graph_edge->Set(Nan::New<String>("name").ToLocalChecked(), name);
+    graph_edge->Set(Nan::New<String>("from").ToLocalChecked(), from);
+    graph_edge->Set(Nan::New<String>("to").ToLocalChecked(), to);
 
-    return NanEscapeScope(graph_edge);
+    return scope.Escape(graph_edge);
   }
 }

--- a/src/heap_graph_node.h
+++ b/src/heap_graph_node.h
@@ -13,8 +13,8 @@ namespace nodex {
       static void Initialize();
       static NAN_METHOD(GetHeapValue);
       static NAN_GETTER(GetChildren);
-      static v8::Persistent<v8::ObjectTemplate> graph_node_template_;
-      static v8::Persistent<v8::Object> graph_node_cache;
+      static Nan::Persistent<v8::ObjectTemplate> graph_node_template_;
+      static Nan::Persistent<v8::Object> graph_node_cache;
   };
 } //namespace nodex
 #endif  // NODE_GRAPH_NODE_

--- a/src/heap_output_stream.cc
+++ b/src/heap_output_stream.cc
@@ -13,11 +13,12 @@ namespace nodex {
   using v8::Integer;
 
   void OutputStreamAdapter::EndOfStream() {
+    Nan::HandleScope scope;
     TryCatch try_catch;
-    callback->Call(NanGetCurrentContext()->Global(), 0, NULL);
+    callback->Call(Nan::GetCurrentContext()->Global(), 0, NULL);
 
     if (try_catch.HasCaught()) {
-      NanThrowError(try_catch.Exception());
+      Nan::ThrowError(try_catch.Exception());
     }
   }
       
@@ -26,18 +27,18 @@ namespace nodex {
   }
 
   OutputStream::WriteResult OutputStreamAdapter::WriteAsciiChunk(char* data, int size) {
-    NanScope();
+    Nan::HandleScope scope;
 
     Handle<Value> argv[2] = {
-      NanNew<String>(data, size),
-      NanNew<Integer>(size)
+      Nan::New<String>(data, size).ToLocalChecked(),
+      Nan::New<Integer>(size)
     };
 
     TryCatch try_catch;
-    abort = iterator->Call(NanGetCurrentContext()->Global(), 2, argv);
+    abort = iterator->Call(Nan::GetCurrentContext()->Global(), 2, argv);
 
     if (try_catch.HasCaught()) {
-      NanThrowError(try_catch.Exception());
+      Nan::ThrowError(try_catch.Exception());
       return kAbort;
     }
     
@@ -45,23 +46,23 @@ namespace nodex {
   }
   
   OutputStream::WriteResult OutputStreamAdapter::WriteHeapStatsChunk(HeapStatsUpdate* data, int count) {
-    NanScope();
+    Nan::HandleScope scope;
     
-    Local<Array> samples = NanNew<Array>();
+    Local<Array> samples = Nan::New<Array>();
     for (int index = 0; index < count; index++) {
       int offset = index * 3;
-      samples->Set(offset, NanNew<Integer>(data[index].index));
-      samples->Set(offset+1, NanNew<Integer>(data[index].count));
-      samples->Set(offset+2, NanNew<Integer>(data[index].size));
+      samples->Set(offset, Nan::New<Integer>(data[index].index));
+      samples->Set(offset+1, Nan::New<Integer>(data[index].count));
+      samples->Set(offset+2, Nan::New<Integer>(data[index].size));
     }
 
     Local<Value> argv[1] = {samples};
 
     TryCatch try_catch;
-    abort = iterator->Call(NanGetCurrentContext()->Global(), 1, argv);
+    abort = iterator->Call(Nan::GetCurrentContext()->Global(), 1, argv);
 
     if (try_catch.HasCaught()) {
-      NanThrowError(try_catch.Exception());
+      Nan::ThrowError(try_catch.Exception());
       return kAbort;
     }
 

--- a/src/heap_output_stream.h
+++ b/src/heap_output_stream.h
@@ -11,7 +11,7 @@ class OutputStreamAdapter : public v8::OutputStream {
       OutputStreamAdapter(
         v8::Handle<v8::Function> _iterator, 
         v8::Handle<v8::Function> _callback)
-      : abort(NanFalse()) 
+      : abort(Nan::False()) 
       , iterator(_iterator)
       , callback(_callback) {};
       

--- a/src/heap_snapshot.cc
+++ b/src/heap_snapshot.cc
@@ -13,144 +13,137 @@ namespace nodex {
   using v8::Object;
   using v8::ObjectTemplate;
   using v8::FunctionTemplate;
-  using v8::Persistent;
   using v8::SnapshotObjectId;
   using v8::String;
   using v8::Function;
   using v8::Value;
   
 
-  Persistent<ObjectTemplate> Snapshot::snapshot_template_;
-  Persistent<Array> Snapshot::snapshots;
+  Nan::Persistent<ObjectTemplate> Snapshot::snapshot_template_;
+  Nan::Persistent<Array> Snapshot::snapshots;
 
   void Snapshot::Initialize () {
-    NanScope();
+    Nan::HandleScope scope;
     
-    Local<FunctionTemplate> f = NanNew<FunctionTemplate>();
+    Local<FunctionTemplate> f = Nan::New<FunctionTemplate>();
     Local<ObjectTemplate> o = f->InstanceTemplate();
     o->SetInternalFieldCount(1);
-    o->SetAccessor(NanNew<String>("root"), Snapshot::GetRoot);
-    NODE_SET_METHOD(o, "getNode", Snapshot::GetNode);
-    NODE_SET_METHOD(o, "getNodeById", Snapshot::GetNodeById);
-    NODE_SET_METHOD(o, "delete", Snapshot::Delete);
-    NODE_SET_METHOD(o, "serialize", Snapshot::Serialize);
-    NanAssignPersistent(snapshot_template_, o);
+    Nan::SetAccessor(o, Nan::New<String>("root").ToLocalChecked(), Snapshot::GetRoot);
+    Nan::SetMethod(o, "getNode", Snapshot::GetNode);
+    Nan::SetMethod(o, "getNodeById", Snapshot::GetNodeById);
+    Nan::SetMethod(o, "delete", Snapshot::Delete);
+    Nan::SetMethod(o, "serialize", Snapshot::Serialize);
+    snapshot_template_.Reset(o);
   }
   
   NAN_GETTER(Snapshot::GetRoot) {
-    NanScope();
-    
     Handle<Object> _root;
-    if (args.This()->Has(NanNew<String>("_root"))) { 
-      NanReturnValue(args.This()->GetHiddenValue(NanNew<String>("_root")));
+    if (info.This()->Has(Nan::New<String>("_root").ToLocalChecked())) { 
+      info.GetReturnValue().Set(info.This()->GetHiddenValue(Nan::New<String>("_root").ToLocalChecked()));
     } else {
-      void* ptr = NanGetInternalFieldPointer(args.This(), 0);
+      void* ptr = Nan::GetInternalFieldPointer(info.This(), 0);
       Handle<Value> _root = GraphNode::New(static_cast<HeapSnapshot*>(ptr)->GetRoot());
-      args.This()->SetHiddenValue(NanNew<String>("_root"), _root);
-      NanReturnValue(_root);
+      info.This()->SetHiddenValue(Nan::New<String>("_root").ToLocalChecked(), _root);
+      info.GetReturnValue().Set(_root);
     }
   }
   
   NAN_METHOD(Snapshot::GetNode) {
-    NanScope();
-    
-    if (!args.Length()) {
-      return NanThrowError("No index specified");
-    } else if (!args[0]->IsInt32()) {
-      return NanThrowTypeError("Argument must be an integer");
+    if (!info.Length()) {
+      return Nan::ThrowError("No index specified");
+    } else if (!info[0]->IsInt32()) {
+      return Nan::ThrowTypeError("Argument must be an integer");
     }
     
-    int32_t index = args[0]->Int32Value();
-    void* ptr = NanGetInternalFieldPointer(args.This(), 0);
-    NanReturnValue(GraphNode::New(static_cast<HeapSnapshot*>(ptr)->GetNode(index)));
+    int32_t index = info[0]->Int32Value();
+    void* ptr = Nan::GetInternalFieldPointer(info.This(), 0);
+    info.GetReturnValue().Set(GraphNode::New(static_cast<HeapSnapshot*>(ptr)->GetNode(index)));
   }
   
   NAN_METHOD(Snapshot::GetNodeById) {
-    NanScope();
-    
-    if (!args.Length()) {
-      return NanThrowError("No id specified");
-    } else if (!args[0]->IsInt32()) {
-      return NanThrowTypeError("Argument must be an integer");
+    if (!info.Length()) {
+      return Nan::ThrowError("No id specified");
+    } else if (!info[0]->IsInt32()) {
+      return Nan::ThrowTypeError("Argument must be an integer");
     }
     
-    SnapshotObjectId id = args[0]->Int32Value();
-    void* ptr = NanGetInternalFieldPointer(args.This(), 0);
-    NanReturnValue(GraphNode::New(static_cast<HeapSnapshot*>(ptr)->GetNodeById(id)));
+    SnapshotObjectId id = info[0]->Int32Value();
+    void* ptr = Nan::GetInternalFieldPointer(info.This(), 0);
+    info.GetReturnValue().Set(GraphNode::New(static_cast<HeapSnapshot*>(ptr)->GetNodeById(id)));
   }
   
   NAN_METHOD(Snapshot::Serialize) {
-    NanScope();
-    
-    void* ptr = NanGetInternalFieldPointer(args.This(), 0);
-    if (args.Length() < 2) {
-      return NanThrowError("Invalid number of arguments");
-    } else if (!args[0]->IsFunction() || !args[1]->IsFunction()) {
-      return NanThrowTypeError("Arguments must be a functions");
+    void* ptr = Nan::GetInternalFieldPointer(info.This(), 0);
+    if (info.Length() < 2) {
+      return Nan::ThrowError("Invalid number of arguments");
+    } else if (!info[0]->IsFunction() || !info[1]->IsFunction()) {
+      return Nan::ThrowTypeError("Arguments must be a functions");
     }
 
-    Handle<Function> iterator = Handle<Function>::Cast(args[0]);
-    Handle<Function> callback = Handle<Function>::Cast(args[1]);
+    Handle<Function> iterator = Handle<Function>::Cast(info[0]);
+    Handle<Function> callback = Handle<Function>::Cast(info[1]);
   
     OutputStreamAdapter *stream = new OutputStreamAdapter(iterator, callback);
     static_cast<HeapSnapshot*>(ptr)->Serialize(stream, HeapSnapshot::kJSON);
-    
-    NanReturnUndefined();
   }  
 
   NAN_METHOD(Snapshot::Delete) {
-    NanScope();
-
-    void* ptr = NanGetInternalFieldPointer(args.Holder(), 0);
-    Local<Array> snapshots = NanNew<Array>(Snapshot::snapshots);
+    void* ptr = Nan::GetInternalFieldPointer(info.Holder(), 0);
+    Local<Array> snapshots = Nan::New<Array>(Snapshot::snapshots);
     
     uint32_t count = snapshots->Length();
     for (uint32_t index = 0; index < count; index++) {
-      if (snapshots->Get(index) == args.This()) {
+      if (snapshots->Get(index) == info.This()) {
         Local<Value> argv[2] = {
-          NanNew<Integer>(index),
-          NanNew<Integer>(1)
+          Nan::New<Integer>(index),
+          Nan::New<Integer>(1)
         };
-        Handle<Function>::Cast(snapshots->Get(NanNew<String>("splice")))->Call(snapshots, 2, argv);
+        Handle<Function>::Cast(snapshots->Get(Nan::New<String>("splice").ToLocalChecked()))->Call(snapshots, 2, argv);
         break;
       }
     }
     static_cast<HeapSnapshot*>(ptr)->Delete();
-
-    NanReturnUndefined();
   }
   
   Handle<Value> Snapshot::New(const HeapSnapshot* node) {
-    NanEscapableScope();
+    Nan::EscapableHandleScope scope;
 
     if (snapshot_template_.IsEmpty()) {
       Snapshot::Initialize();
     }
 
-    Local<Object> snapshot = NanNew(snapshot_template_)->NewInstance();
-    NanSetInternalFieldPointer(snapshot, 0, const_cast<HeapSnapshot*>(node));
+    Local<Object> snapshot = Nan::New(snapshot_template_)->NewInstance();
+    Nan::SetInternalFieldPointer(snapshot, 0, const_cast<HeapSnapshot*>(node));
 
-    Local<Value> HEAP = NanNew<String>("HEAP");
+    Local<Value> HEAP = Nan::New<String>("HEAP").ToLocalChecked();
+#if (NODE_MODULE_VERSION > 0x002C)      
+    // starting with iojs 3 GetUid() and GetTitle() APIs were removed
+    uint16_t _uid = node->GetMaxSnapshotJSObjectId();
+    char _title[32];
+    sprintf(_title, "Snapshot %i", _uid);
+    Handle<String> title = Nan::New<String>(_title).ToLocalChecked();
+#else
     uint16_t _uid = node->GetUid();
-    Local<Value> uid = NanNew<Integer>(_uid);
     Handle<String> title = node->GetTitle();
     if (!title->Length()) {
       char _title[32];
       sprintf(_title, "Snapshot %i", _uid);
-      title = NanNew<String>(_title);
+      title = Nan::New<String>(_title).ToLocalChecked();
     }
-    Local<Integer> nodesCount = NanNew<Integer>(node->GetNodesCount());
-    Local<Integer> objectId = NanNew<Integer>(node->GetMaxSnapshotJSObjectId());
+#endif
+    Local<Value> uid = Nan::New<Integer>(_uid);
+    Local<Integer> nodesCount = Nan::New<Integer>(node->GetNodesCount());
+    Local<Integer> objectId = Nan::New<Integer>(node->GetMaxSnapshotJSObjectId());
 
-    snapshot->Set(NanNew<String>("typeId"), HEAP);
-    snapshot->Set(NanNew<String>("title"), title);
-    snapshot->Set(NanNew<String>("uid"), uid);
-    snapshot->Set(NanNew<String>("nodesCount"), nodesCount);
-    snapshot->Set(NanNew<String>("maxSnapshotJSObjectId"), objectId);
+    snapshot->Set(Nan::New<String>("typeId").ToLocalChecked(), HEAP);
+    snapshot->Set(Nan::New<String>("title").ToLocalChecked(), title);
+    snapshot->Set(Nan::New<String>("uid").ToLocalChecked(), uid);
+    snapshot->Set(Nan::New<String>("nodesCount").ToLocalChecked(), nodesCount);
+    snapshot->Set(Nan::New<String>("maxSnapshotJSObjectId").ToLocalChecked(), objectId);
 
-    Local<Array> snapshots = NanNew<Array>(Snapshot::snapshots);
+    Local<Array> snapshots = Nan::New<Array>(Snapshot::snapshots);
     snapshots->Set(snapshots->Length(), snapshot);
 
-    return NanEscapeScope(snapshot);
+    return scope.Escape(snapshot);
   }
 }

--- a/src/heap_snapshot.h
+++ b/src/heap_snapshot.h
@@ -9,7 +9,7 @@ namespace nodex {
   class Snapshot {
     public:
       static v8::Handle<v8::Value> New(const v8::HeapSnapshot* node);
-      static v8::Persistent<v8::Array> snapshots;
+      static Nan::Persistent<v8::Array> snapshots;
     private:
       static void Initialize();
       static NAN_GETTER(GetRoot);
@@ -17,7 +17,7 @@ namespace nodex {
       static NAN_METHOD(GetNodeById);
       static NAN_METHOD(Delete);
       static NAN_METHOD(Serialize);
-      static v8::Persistent<v8::ObjectTemplate> snapshot_template_;
+      static Nan::Persistent<v8::ObjectTemplate> snapshot_template_;
   };
 } //namespace nodex
 #endif  // NODE_SNAPSHOT_

--- a/src/profiler.cc
+++ b/src/profiler.cc
@@ -5,7 +5,7 @@
 
 namespace nodex {
   void InitializeProfiler(v8::Handle<v8::Object> target) {
-    NanScope();
+    Nan::HandleScope scope;
     HeapProfiler::Initialize(target);
     CpuProfiler::Initialize(target);
   }

--- a/test/cpu_cprofiler.js
+++ b/test/cpu_cprofiler.js
@@ -5,7 +5,9 @@ const expect  = require('chai').expect,
       binding = require(binding_path),
       profiler = require('../');
 
+
 const NODE_V_10 = /^v0\.10\.\d+$/.test(process.version);
+const NODE_V_3 = /^v3\./.test(process.version);
     
 describe('Profiler container', function() {
 
@@ -54,6 +56,9 @@ describe('CPU', function() {
     });
     
     it('should replace profile title, if started with name argument', function() {
+      // starting with nodejs v3.x v8 doesn't support setting custom snapshot title
+      if (NODE_V_3) return;
+
       binding.cpu.startProfiling('P');
       var profile = binding.cpu.stopProfiling();
       expect(profile.title).to.equal('P');
@@ -154,6 +159,7 @@ describe('HEAP', function() {
     });
     
     it('should replace snapshot title, if started with name argument', function() {
+      if (NODE_V_3) return;
       var snapshot = binding.heap.takeSnapshot('S');
       expect(snapshot.title).to.equal('S');
     });


### PR DESCRIPTION
- most changes applied via:
  https://gist.github.com/thlorenz/7e9d8ad15566c99fd116
- minor manual fixes applied
- heap_snapshot.cc: worked around fact that GetUid and GetTitle were
  removed from v8-profiler API
- heap_profiler.cc: fixed call to TakeHeapSnapshot to no longer pass a
  title
- using Nan::Persistent instead of v8::Persistent
- removing `HandleScope` from NAN_METHOD`s since they are provided in that
  case already

I was able to build directly with node 3.x (integrated v8-profiler source files and used `_linkedBinding`).

Testing with node-gyp has mixed results.
I'm running: `node-pre-gyp reinstall --build-from-source`

But with iojs 3.1 I get:

```
gyp http GET http://nodejs.org/dist/v3.1.0/node-v3.1.0.tar.gz
gyp WARN install got an error, rolling back install
gyp ERR! configure error
gyp ERR! stack Error: connect ETIMEDOUT 165.225.133.150:80
```
Maybe I'll try that part later if this is a server issue (not sure).

Similarly for iojs 2.5:

```
gyp http GET http://nodejs.org/dist/v2.5.0/node-v2.5.0.tar.gz
gyp http 404 http://nodejs.org/dist/v2.5.0/node-v2.5.0.tar.gz
gyp WARN install got an error, rolling back install
```

With older nodes it at least starts building, but complains about `Set` method signature, i.e.:

```
../src/cpu_profiler.cc:80:27: error: no matching member function for call to 'Set'
    info.GetReturnValue().Set(Profile::New(profile));
```

Hoping for some nan expert like @rvagg or @kkoopa to lend some advice.