### PR TITLE
Add "increaseHeapLimit" and "restoreHeapLimit"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
     secure: jJxKoyWputzRz2EjAT9i/vBzYt2+lcjKZ5D6O5TBaS9+anpYHn2XWbOut5dkOgh0
   node_pre_gyp_region: eu-central-1
   matrix:
+    - NODE_VERSION: 8
+      platform: x64
+    - NODE_VERSION: 8
+      platform: x86
     - NODE_VERSION: 7
       platform: x64
     - NODE_VERSION: 7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v8-profiler",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "node bindings for the v8 profiler",
   "homepage": "http://github.com/node-inspector/v8-profiler",
   "author": "Danny Coates <dannycoates@gmail.com>",
@@ -30,7 +30,7 @@
     "inspector"
   ],
   "engines": {
-    "node": ">=0.10"
+    "node": ">=8.0"
   },
   "main": "v8-profiler",
   "dependencies": {
@@ -49,6 +49,6 @@
     "install": "node-pre-gyp install --fallback-to-build",
     "rebuild": "node-pre-gyp rebuild",
     "release": "node ./tools/release.js $@",
-    "test": "mocha --debug"
+    "test": "mocha"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ var profiler = require('v8-profiler');
 ## API
 `takeSnapshot([name])` - returns new HEAP Snapshot instance. `name` is optional argument, by default snapshot name will be constructed from his uid.
 
+`increaseHeapLimit()` - Tells V8 the current isolate is used for debugging and requires a higher heap limit. Useful when you want to take a heap snapshot just before an out of memory occurs.
+
 `deleteAllSnapshots()` - works as described in name.
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ var profiler = require('v8-profiler');
 
 `increaseHeapLimit()` - Tells V8 the current isolate is used for debugging and requires a higher heap limit. Useful when you want to take a heap snapshot just before an out of memory occurs.
 
+`restoreHeapLimit()` - Restores the original heap limit after `increaseHeapLimit()` was called.
+
 `deleteAllSnapshots()` - works as described in name.
 
 ```js

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ var profiler = require('v8-profiler');
 ## API
 `takeSnapshot([name])` - returns new HEAP Snapshot instance. `name` is optional argument, by default snapshot name will be constructed from his uid.
 
-`increaseHeapLimit()` - Node.js 8+: Tells V8 the current isolate is used for debugging and requires a higher heap limit. Useful when you want to take a heap snapshot just before an out of memory occurs. Throws exception for Node.js versions <8.
+`increaseHeapLimit()` - Node.js 8+: Tells V8 the current isolate is used for debugging and requires a higher heap limit. Useful when you want to take a heap snapshot just before an out of memory occurs.
 
-`restoreHeapLimit()` - Node.js 8+: Restores the original heap limit after `increaseHeapLimit()` was called. Throws exception for Node.js versions <8.
+`restoreHeapLimit()` - Node.js 8+: Restores the original heap limit after `increaseHeapLimit()` was called.
 
 `deleteAllSnapshots()` - works as described in name.
 

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ var profiler = require('v8-profiler');
 ## API
 `takeSnapshot([name])` - returns new HEAP Snapshot instance. `name` is optional argument, by default snapshot name will be constructed from his uid.
 
-`increaseHeapLimit()` - Tells V8 the current isolate is used for debugging and requires a higher heap limit. Useful when you want to take a heap snapshot just before an out of memory occurs.
+`increaseHeapLimit()` - Node.js 8+: Tells V8 the current isolate is used for debugging and requires a higher heap limit. Useful when you want to take a heap snapshot just before an out of memory occurs. Throws exception for Node.js versions <8.
 
-`restoreHeapLimit()` - Restores the original heap limit after `increaseHeapLimit()` was called.
+`restoreHeapLimit()` - Node.js 8+: Restores the original heap limit after `increaseHeapLimit()` was called. Throws exception for Node.js versions <8.
 
 `deleteAllSnapshots()` - works as described in name.
 

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -55,6 +55,7 @@ namespace nodex {
     Local<Object> snapshots = Nan::New<Object>();
 
     Nan::SetMethod(heapProfiler, "increaseHeapLimit", HeapProfiler::IncreaseHeapLimit);
+    Nan::SetMethod(heapProfiler, "restoreHeapLimit", HeapProfiler::RestoreHeapLimit);
     Nan::SetMethod(heapProfiler, "takeSnapshot", HeapProfiler::TakeSnapshot);
     Nan::SetMethod(heapProfiler, "startTrackingHeapObjects", HeapProfiler::StartTrackingHeapObjects);
     Nan::SetMethod(heapProfiler, "stopTrackingHeapObjects", HeapProfiler::StopTrackingHeapObjects);
@@ -69,6 +70,11 @@ namespace nodex {
 
   NAN_METHOD(HeapProfiler::IncreaseHeapLimit) {
     v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
+    return;
+  }
+
+  NAN_METHOD(HeapProfiler::RestoreHeapLimit) {
+    v8::Isolate::GetCurrent()->RestoreOriginalHeapLimit();
     return;
   }
 

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -69,12 +69,20 @@ namespace nodex {
   }
 
   NAN_METHOD(HeapProfiler::IncreaseHeapLimit) {
-    v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
+#if (NODE_MODULE_VERSION > 0x0038)
+      v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
+#elif
+      throw std::runtime_error("IncreaseHeapLimitForDebugging is only available from Node.js v8+");
+#endif
     return;
   }
 
   NAN_METHOD(HeapProfiler::RestoreHeapLimit) {
-    v8::Isolate::GetCurrent()->RestoreOriginalHeapLimit();
+#if (NODE_MODULE_VERSION > 0x0038)
+      v8::Isolate::GetCurrent()->RestoreOriginalHeapLimit();
+#elif
+      throw std::runtime_error("RestoreOriginalHeapLimit is only available from Node.js v8+");
+#endif
     return;
   }
 

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -1,6 +1,7 @@
 #include "heap_profiler.h"
 #include "heap_snapshot.h"
 #include "heap_output_stream.h"
+#include <stdexcept>
 
 namespace nodex {
   using v8::ActivityControl;

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -72,7 +72,7 @@ namespace nodex {
   NAN_METHOD(HeapProfiler::IncreaseHeapLimit) {
 #if (NODE_MODULE_VERSION > 0x0038)
       v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
-#elif
+#else
       throw std::runtime_error("IncreaseHeapLimitForDebugging is only available from Node.js v8+");
 #endif
     return;
@@ -81,7 +81,7 @@ namespace nodex {
   NAN_METHOD(HeapProfiler::RestoreHeapLimit) {
 #if (NODE_MODULE_VERSION > 0x0038)
       v8::Isolate::GetCurrent()->RestoreOriginalHeapLimit();
-#elif
+#else
       throw std::runtime_error("RestoreOriginalHeapLimit is only available from Node.js v8+");
 #endif
     return;

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -1,7 +1,6 @@
 #include "heap_profiler.h"
 #include "heap_snapshot.h"
 #include "heap_output_stream.h"
-#include <stdexcept>
 
 namespace nodex {
   using v8::ActivityControl;
@@ -71,20 +70,14 @@ namespace nodex {
 
   NAN_METHOD(HeapProfiler::IncreaseHeapLimit) {
 #if (NODE_MODULE_VERSION > 0x0038)
-      v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
-#else
-      throw std::runtime_error("IncreaseHeapLimitForDebugging is only available from Node.js v8+");
+    v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
 #endif
-    return;
   }
 
   NAN_METHOD(HeapProfiler::RestoreHeapLimit) {
 #if (NODE_MODULE_VERSION > 0x0038)
-      v8::Isolate::GetCurrent()->RestoreOriginalHeapLimit();
-#else
-      throw std::runtime_error("RestoreOriginalHeapLimit is only available from Node.js v8+");
+    v8::Isolate::GetCurrent()->RestoreOriginalHeapLimit();
 #endif
-    return;
   }
 
   NAN_METHOD(HeapProfiler::TakeSnapshot) {

--- a/src/heap_profiler.cc
+++ b/src/heap_profiler.cc
@@ -54,6 +54,7 @@ namespace nodex {
     Local<Object> heapProfiler = Nan::New<Object>();
     Local<Object> snapshots = Nan::New<Object>();
 
+    Nan::SetMethod(heapProfiler, "increaseHeapLimit", HeapProfiler::IncreaseHeapLimit);
     Nan::SetMethod(heapProfiler, "takeSnapshot", HeapProfiler::TakeSnapshot);
     Nan::SetMethod(heapProfiler, "startTrackingHeapObjects", HeapProfiler::StartTrackingHeapObjects);
     Nan::SetMethod(heapProfiler, "stopTrackingHeapObjects", HeapProfiler::StopTrackingHeapObjects);
@@ -66,13 +67,20 @@ namespace nodex {
     target->Set(Nan::New<String>("heap").ToLocalChecked(), heapProfiler);
   }
 
+  NAN_METHOD(HeapProfiler::IncreaseHeapLimit) {
+    v8::Isolate::GetCurrent()->IncreaseHeapLimitForDebugging();
+    return;
+  }
+
   NAN_METHOD(HeapProfiler::TakeSnapshot) {
     ActivityControlAdapter* control = new ActivityControlAdapter(info[1]);
 #if (NODE_MODULE_VERSION < 0x000F)
     Local<String> title = info[0]->ToString();
 #endif
 
-#if (NODE_MODULE_VERSION > 0x002C)
+#if (NODE_MODULE_VERSION > 0x0038)
+    const HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->TakeHeapSnapshot();
+#elif (NODE_MODULE_VERSION > 0x002C)
     const HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->TakeHeapSnapshot(control);
 #elif (NODE_MODULE_VERSION > 0x000B)
     const HeapSnapshot* snapshot = v8::Isolate::GetCurrent()->GetHeapProfiler()->TakeHeapSnapshot(title, control);

--- a/src/heap_profiler.h
+++ b/src/heap_profiler.h
@@ -15,6 +15,7 @@ namespace nodex {
 
     protected:
       static NAN_METHOD(IncreaseHeapLimit);
+      static NAN_METHOD(RestoreHeapLimit);
       static NAN_METHOD(TakeSnapshot);
       static NAN_METHOD(StartTrackingHeapObjects);
       static NAN_METHOD(StopTrackingHeapObjects);

--- a/src/heap_profiler.h
+++ b/src/heap_profiler.h
@@ -14,6 +14,7 @@ namespace nodex {
       virtual ~HeapProfiler();
 
     protected:
+      static NAN_METHOD(IncreaseHeapLimit);
       static NAN_METHOD(TakeSnapshot);
       static NAN_METHOD(StartTrackingHeapObjects);
       static NAN_METHOD(StopTrackingHeapObjects);

--- a/test/binding.js
+++ b/test/binding.js
@@ -87,6 +87,7 @@ describe('binding', function() {
       it('has expected structure', function() {
         var properties = [
           'increaseHeapLimit',
+          'restoreHeapLimit',
           'takeSnapshot',
           'startTrackingHeapObjects',
           'stopTrackingHeapObjects',

--- a/test/binding.js
+++ b/test/binding.js
@@ -86,6 +86,7 @@ describe('binding', function() {
     describe('Profiler', function() {
       it('has expected structure', function() {
         var properties = [
+          'increaseHeapLimit',
           'takeSnapshot',
           'startTrackingHeapObjects',
           'stopTrackingHeapObjects',

--- a/test/v8-profiler.js
+++ b/test/v8-profiler.js
@@ -90,17 +90,17 @@ describe('v8-profiler', function() {
       });
 
       it('should increase heap limit without arguments (node8 only)', function() {
-        if (NODE_V_010) {
+        if (!NODE_V_8x) {
           expect(profiler.increaseHeapLimit).to.throw();
-        } else if (NODE_V_8x){
+        } else {
           expect(profiler.increaseHeapLimit).to.not.throw();
         }
       });
 
       it('should restore heap limit without arguments (node8 only)', function() {
-        if (NODE_V_010) {
+        if (!NODE_V_8x) {
           expect(profiler.restoreHeapLimit).to.throw();
-        } else if (NODE_V_8x){
+        } else {
           expect(profiler.restoreHeapLimit).to.not.throw();
         }
       });

--- a/test/v8-profiler.js
+++ b/test/v8-profiler.js
@@ -90,17 +90,13 @@ describe('v8-profiler', function() {
       });
 
       it('should increase heap limit without arguments (node8 only)', function() {
-        if (!NODE_V_8x) {
-          expect(profiler.increaseHeapLimit).to.throw();
-        } else {
+        if (NODE_V_8x) {
           expect(profiler.increaseHeapLimit).to.not.throw();
         }
       });
 
       it('should restore heap limit without arguments (node8 only)', function() {
-        if (!NODE_V_8x) {
-          expect(profiler.restoreHeapLimit).to.throw();
-        } else {
+        if (NODE_V_8x) {
           expect(profiler.restoreHeapLimit).to.not.throw();
         }
       });

--- a/test/v8-profiler.js
+++ b/test/v8-profiler.js
@@ -2,6 +2,7 @@ const expect  = require('chai').expect,
       profiler = require('../');
 
 const NODE_V_010 = /^v0\.10\.\d+$/.test(process.version);
+const NODE_V_8x = process.version.indexOf("v8.") === 0;
 
 describe('v8-profiler', function() {
   describe('CPU', function() {
@@ -88,6 +89,14 @@ describe('v8-profiler', function() {
         expect(profiler.takeSnapshot).to.not.throw();
       });
 
+      it('should increase heap limit without arguments (node8 only)', function() {
+        if (NODE_V_010) {
+          expect(profiler.increaseHeapLimit).to.throw();
+        } else if (NODE_V_8x){
+          expect(profiler.increaseHeapLimit).to.not.throw();
+        }
+      });
+
       it('should cache snapshots', function() {
         expect(Object.keys(profiler.snapshots)).to.have.length(1);
       });
@@ -98,15 +107,20 @@ describe('v8-profiler', function() {
       });
 
       it('should use control function, if started with function argument', function(done) {
-        // Fix for Windows
-        var checked = false;
-        profiler.takeSnapshot(function(progress, total) {
-          if (progress === total) {
-            if (checked) return;
-            checked = true;
-            done();
-          }
-        });
+        if (NODE_V_010) {
+          // Fix for Windows
+          var checked = false;
+          profiler.takeSnapshot(function(progress, total) {
+            if (progress === total) {
+              if (checked) return;
+              checked = true;
+              done();
+            }
+          });
+        } else if (NODE_V_8x){
+          profiler.takeSnapshot();
+          done();
+        }
       });
 
       it('should write heap stats', function(done) {

--- a/test/v8-profiler.js
+++ b/test/v8-profiler.js
@@ -115,7 +115,7 @@ describe('v8-profiler', function() {
       });
 
       it('should use control function, if started with function argument', function(done) {
-        if (NODE_V_010) {
+        if (!NODE_V_8x) {
           // Fix for Windows
           var checked = false;
           profiler.takeSnapshot(function(progress, total) {
@@ -125,7 +125,7 @@ describe('v8-profiler', function() {
               done();
             }
           });
-        } else if (NODE_V_8x){
+        } else {
           profiler.takeSnapshot();
           done();
         }

--- a/test/v8-profiler.js
+++ b/test/v8-profiler.js
@@ -97,6 +97,14 @@ describe('v8-profiler', function() {
         }
       });
 
+      it('should restore heap limit without arguments (node8 only)', function() {
+        if (NODE_V_010) {
+          expect(profiler.restoreHeapLimit).to.throw();
+        } else if (NODE_V_8x){
+          expect(profiler.restoreHeapLimit).to.not.throw();
+        }
+      });
+
       it('should cache snapshots', function() {
         expect(Object.keys(profiler.snapshots)).to.have.length(1);
       });

--- a/v8-profiler.js
+++ b/v8-profiler.js
@@ -142,6 +142,10 @@ var profiler = {
     binding.heap.increaseHeapLimit();
   },
 
+  restoreHeapLimit: function(){
+    binding.heap.restoreHeapLimit();
+  },
+
   takeSnapshot: function(name, control) {
     if (typeof name == 'function') {
       control = name;

--- a/v8-profiler.js
+++ b/v8-profiler.js
@@ -138,6 +138,10 @@ var profiler = {
 
   get snapshots() { return binding.heap.snapshots; },
 
+  increaseHeapLimit: function(){
+    binding.heap.increaseHeapLimit();
+  },
+
   takeSnapshot: function(name, control) {
     if (typeof name == 'function') {
       control = name;


### PR DESCRIPTION
In order to be able to create a heapdump just before an out of memory occurs, it's necessary to increase the heap limit. Otherwise the heapdump cannot be created. See discussion (and code) in
https://github.com/node-inspector/v8-profiler/issues/109.

These API calls are only available from Node8, so this pull request also incorporates this [pull request ](https://github.com/node-inspector/v8-profiler/pull/113).

I've updated the documentation and unit tests as well.

With this change i can monitor the (Full) GC's and when an out of memory seems imminent, the heap limit can be increased to allow for proper heapdump creation. For completeness the "restoreHeapLimit" function is also added.