### PR TITLE
update node-pre-gyp dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "main": "v8-profiler",
   "dependencies": {
     "nan": "^2.5.1",
-    "node-pre-gyp": "^0.6.34"
+    "node-pre-gyp": "^0.8.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.0.0",


### PR DESCRIPTION
The outdated node-pre-gyp dependency triggers the Node Security
Project scanner.

See https://nodesecurity.io/advisories/566